### PR TITLE
Add onion server (links to dash-electrum.pshenmic.dev)

### DIFF
--- a/electrum_dash/servers.json
+++ b/electrum_dash/servers.json
@@ -3,5 +3,10 @@
         "pruning": "-",
         "s": "50002",
         "version": "1.4"
+    },
+    "rnxogu42f3pq3e3oo7shqmh7mtema6c5fhhhsi54din4olzlu7vsx2id.onion": {
+        "pruning": "-",
+        "s": "50002",
+        "version": "1.4"
     }
 }


### PR DESCRIPTION
# Issue
Previous onion server wasn't responding and were removed from the dash electrum in https://github.com/Bertrand256/electrum-dash/pull/9. I fixed that by deploying a new Tor Onion Service at pshenmic.dev.

# Things done
* deployed dash electrum Tor service (`rnxogu42f3pq3e3oo7shqmh7mtema6c5fhhhsi54din4olzlu7vsx2id.onion:50002`)
* added tor server url in the hardcoded servers list